### PR TITLE
Change default of keyCombinationsOnly to false

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ const config = {
 		title: 'Key Combinations Only',
 		description: 'When enabled, the UI will only show for combinations with accelerators.',
 		type: 'boolean',
-		default: true
+		default: false
 	},
 	centerInCropper: {
 		title: 'Center in Cropper',


### PR DESCRIPTION
Hi @karaggeorge,

First of all, thanks for this awesome plugin! Really nice to have this built in to Kap!

This pull request changes the default of `keyCombinationsOnly` to `false`. I would suggest this as the default because of my experience when installing the plugin, which I can imagine could happen to others too:

A. I installed the plugin and tried it out quickly on a GitHub page
B. I tried keyboard combinations and everything was great
C. I tried a single shortcut key <kbd>e</kbd>, and nothing showed up

This led me to believe that the plugin did not support this, which led me to search through the GitHub repos for any open issues (in case others also have wanted this).

I then found the configuration option.

---

So what I would suggest is that the plugin should by default capture all keys, and then if users want to capture something that would require typing (which could be super annoying with all keys showing), they could configure this.

However, to play devil's advocate, I can understand if the use case of capturing typing is considered too primary for your customers, which would be a reason not to accept this PR.

What are your thoughts?